### PR TITLE
add conduit-lwt-tls to cohttp-lwt-unix dependencies

### DIFF
--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.6.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.6.0/opam
@@ -29,6 +29,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "conduit-lwt" {>= "1.0.3"}
   "conduit-lwt-ssl"
+  "conduit-lwt-tls"
   "cmdliner"
   "magic-mime"
   "logs"


### PR DESCRIPTION
File "cohttp-lwt-unix/src/dune", line 8, characters 3-18:
8 |    conduit-lwt-tls magic-mime lwt.unix cohttp cohttp-lwt))
       ^^^^^^^^^^^^^^^
Error: Library "conduit-lwt-tls" not found.